### PR TITLE
Add initial GrowLab Gatsby setup and components

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -1,0 +1,21 @@
+import type { GatsbyConfig } from 'gatsby';
+
+const config: GatsbyConfig = {
+  siteMetadata: {
+    title: 'GrowLab',
+    siteUrl: 'https://growlab.dev',
+  },
+  plugins: [
+    'gatsby-plugin-postcss',
+    {
+      resolve: 'gatsby-source-filesystem',
+      options: {
+        path: `${__dirname}/src/data/blog-posts`,
+        name: 'blog',
+      },
+    },
+    'gatsby-transformer-remark',
+  ],
+};
+
+export default config;

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -1,0 +1,25 @@
+import { GatsbyNode } from 'gatsby';
+import path from 'path';
+
+export const onCreateNode: GatsbyNode['onCreateNode'] = ({ node, actions }) => {
+  const { createNodeField } = actions;
+  if (node.internal.type === 'MarkdownRemark') {
+    const slug = `/blog/${path.basename(node.fileAbsolutePath, '.md')}/`;
+    createNodeField({ node, name: 'slug', value: slug });
+  }
+};
+
+export const createPages: GatsbyNode['createPages'] = async ({ graphql, actions }) => {
+  const { createPage } = actions;
+  const result: any = await graphql(`
+    { allMarkdownRemark { nodes { fields { slug } } } }
+  `);
+
+  result.data.allMarkdownRemark.nodes.forEach((node: any) => {
+    createPage({
+      path: node.fields.slug,
+      component: path.resolve('./src/templates/blog-post.tsx'),
+      context: { slug: node.fields.slug },
+    });
+  });
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "grow-lab",
+  "private": true,
+  "scripts": {
+    "develop": "gatsby develop",
+    "build": "gatsby build",
+    "test": "echo \"No tests specified\""
+  },
+  "dependencies": {
+    "gatsby": "^5.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
+  },
+  "devDependencies": {
+    "tailwindcss": "^3.0.0",
+    "postcss": "^8.0.0",
+    "autoprefixer": "^10.0.0",
+    "typescript": "^4.0.0"
+  }
+}

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import Container from '../shared/Container';
+import Logo from '../shared/Logo';
+
+const Footer = () => (
+  <footer className="bg-gray-50 py-12 text-sm text-gray-500">
+    <Container className="flex flex-col items-center space-y-4">
+      <Logo />
+      <p>&copy; {new Date().getFullYear()} GrowLab. All rights reserved.</p>
+    </Container>
+  </footer>
+);
+
+export default Footer;

--- a/src/components/layout/GlobalStyles.css
+++ b/src/components/layout/GlobalStyles.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+html {
+  scroll-behavior: smooth;
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import Logo from '../shared/Logo';
+import Nav from './Nav';
+import Button from '../ui/Button';
+import Container from '../shared/Container';
+
+const Header = () => (
+  <header className="bg-white shadow-sm">
+    <Container className="flex items-center justify-between py-6">
+      <Logo />
+      <div className="hidden md:block">
+        <Nav />
+      </div>
+      <div className="ml-4 hidden md:block">
+        <Button as="a" href="/contact">
+          Get Started
+        </Button>
+      </div>
+    </Container>
+  </header>
+);
+
+export default Header;

--- a/src/components/layout/Nav.tsx
+++ b/src/components/layout/Nav.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Link } from 'gatsby';
+
+const links = [
+  { to: '/products', label: 'Products' },
+  { to: '/website-plans', label: 'Website Plans' },
+  { to: '/blog', label: 'Blog' },
+  { to: '/contact', label: 'Contact' },
+];
+
+const Nav = () => (
+  <nav className="space-x-8 text-sm font-medium text-gray-600">
+    {links.map((link) => (
+      <Link key={link.to} to={link.to} className="hover:text-gray-900">
+        {link.label}
+      </Link>
+    ))}
+  </nav>
+);
+
+export default Nav;

--- a/src/components/sections/CallToAction.tsx
+++ b/src/components/sections/CallToAction.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import Button from '../ui/Button';
+import Container from '../shared/Container';
+
+const CallToAction = () => (
+  <section className="py-20 bg-blue-600 text-center text-white">
+    <Container>
+      <h2 className="text-3xl font-bold">Ready to level up your digital presence?</h2>
+      <p className="mt-4 text-blue-100">Contact our team to get started today.</p>
+      <Button as="a" href="/contact" className="mt-8 bg-white text-blue-600 hover:bg-blue-50">
+        Get in Touch
+      </Button>
+    </Container>
+  </section>
+);
+
+export default CallToAction;

--- a/src/components/sections/FeatureGrid.tsx
+++ b/src/components/sections/FeatureGrid.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import Icon from '../ui/Icon';
+import Container from '../shared/Container';
+
+const features = [
+  {
+    title: 'AI Tools',
+    description: 'Streamline everyday tasks with simple AI-powered helpers.',
+  },
+  {
+    title: 'WaaS Plans',
+    description: 'Launch a stunning website without lifting a finger.',
+  },
+  {
+    title: 'Automation',
+    description: 'Speed up workflows using ready-made Power Automate templates.',
+  },
+];
+
+const FeatureGrid = () => (
+  <section className="bg-white py-16">
+    <Container>
+      <div className="grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
+        {features.map((feature) => (
+          <div key={feature.title} className="flex items-start space-x-3">
+            <Icon name="check" className="text-blue-600" />
+            <div>
+              <h3 className="text-lg font-medium text-gray-900">{feature.title}</h3>
+              <p className="mt-2 text-gray-600">{feature.description}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+    </Container>
+  </section>
+);
+
+export default FeatureGrid;

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import Button from '../ui/Button';
+import Container from '../shared/Container';
+
+const Hero = () => (
+  <section className="py-20 text-center bg-gradient-to-b from-white to-gray-50">
+    <Container>
+      <h1 className="mx-auto max-w-3xl text-4xl font-extrabold tracking-tight text-gray-900 sm:text-5xl">
+        Build and automate with confidence
+      </h1>
+      <p className="mx-auto mt-6 max-w-xl text-lg text-gray-600">
+        Lightweight AI tools, beautiful websites, and automation templates to grow your business.
+      </p>
+      <div className="mt-8 flex justify-center space-x-4">
+        <Button as="a" href="/products">Explore Products</Button>
+        <Button variant="secondary" as="a" href="/contact">Start a Project</Button>
+      </div>
+    </Container>
+  </section>
+);
+
+export default Hero;

--- a/src/components/sections/PricingTable.tsx
+++ b/src/components/sections/PricingTable.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import Card from '../ui/Card';
+import Button from '../ui/Button';
+import Container from '../shared/Container';
+
+const plans = [
+  {
+    name: 'Starter',
+    price: '$49/mo',
+    features: ['Up to 5 pages', 'Basic SEO', 'Email support'],
+  },
+  {
+    name: 'Growth',
+    price: '$99/mo',
+    features: ['Up to 15 pages', 'SEO optimization', 'Priority support'],
+  },
+  {
+    name: 'Scale',
+    price: '$199/mo',
+    features: ['Unlimited pages', 'Custom integrations', 'Dedicated support'],
+  },
+];
+
+const PricingTable = () => (
+  <section className="bg-gray-50 py-16">
+    <Container>
+      <div className="grid gap-8 md:grid-cols-3">
+        {plans.map((plan) => (
+          <Card key={plan.name} title={plan.name} className="text-center">
+            <p className="mt-2 text-3xl font-extrabold text-gray-900">{plan.price}</p>
+            <ul className="mt-6 space-y-2 text-sm text-gray-600">
+              {plan.features.map((f) => (
+                <li key={f} className="flex items-center justify-center space-x-2">
+                  <span>{f}</span>
+                </li>
+              ))}
+            </ul>
+            <Button className="mt-6 w-full">Choose Plan</Button>
+          </Card>
+        ))}
+      </div>
+    </Container>
+  </section>
+);
+
+export default PricingTable;

--- a/src/components/sections/Testimonials.tsx
+++ b/src/components/sections/Testimonials.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import Container from '../shared/Container';
+import Card from '../ui/Card';
+import testimonials from '../../data/testimonials.json';
+
+const Testimonials = () => (
+  <section className="py-16 bg-white">
+    <Container>
+      <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
+        {testimonials.map((t) => (
+          <Card key={t.author} title={t.author}>
+            <p className="text-gray-600">{t.quote}</p>
+          </Card>
+        ))}
+      </div>
+    </Container>
+  </section>
+);
+
+export default Testimonials;

--- a/src/components/shared/Container.tsx
+++ b/src/components/shared/Container.tsx
@@ -1,0 +1,14 @@
+import React, { ReactNode } from 'react';
+
+interface ContainerProps {
+  children: ReactNode;
+  className?: string;
+}
+
+const Container = ({ children, className = '' }: ContainerProps) => (
+  <div className={`mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 ${className}`}>
+    {children}
+  </div>
+);
+
+export default Container;

--- a/src/components/shared/Logo.tsx
+++ b/src/components/shared/Logo.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { Link } from 'gatsby';
+
+const Logo = () => (
+  <Link to="/" className="text-xl font-bold tracking-tight text-blue-600">
+    GrowLab
+  </Link>
+);
+
+export default Logo;

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,0 +1,21 @@
+import React, { ButtonHTMLAttributes } from 'react';
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'primary' | 'secondary';
+}
+
+const base =
+  'inline-flex items-center justify-center px-6 py-3 border border-transparent text-sm font-medium rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2';
+
+const variants = {
+  primary: `${base} bg-blue-600 text-white hover:bg-blue-700 focus:ring-blue-500`,
+  secondary: `${base} bg-white text-blue-600 hover:bg-blue-50 border-blue-600 focus:ring-blue-500`,
+};
+
+const Button: React.FC<ButtonProps> = ({ variant = 'primary', children, ...props }) => (
+  <button className={variants[variant]} {...props}>
+    {children}
+  </button>
+);
+
+export default Button;

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -1,0 +1,16 @@
+import React, { ReactNode } from 'react';
+
+interface CardProps {
+  title: string;
+  children: ReactNode;
+  className?: string;
+}
+
+const Card = ({ title, children, className = '' }: CardProps) => (
+  <div className={`rounded-lg bg-white shadow-md p-6 ${className}`}>
+    <h3 className="mb-4 text-lg font-semibold text-gray-900">{title}</h3>
+    {children}
+  </div>
+);
+
+export default Card;

--- a/src/components/ui/Icon.tsx
+++ b/src/components/ui/Icon.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+interface IconProps {
+  name: string;
+  className?: string;
+}
+
+const icons: Record<string, JSX.Element> = {
+  check: (
+    <svg viewBox="0 0 20 20" fill="currentColor" className="h-5 w-5">
+      <path
+        fillRule="evenodd"
+        d="M16.707 5.293a1 1 0 00-1.414 0L8 12.586 4.707 9.293a1 1 0 00-1.414 1.414l4 4a1 1 0 001.414 0l8-8a1 1 0 000-1.414z"
+        clipRule="evenodd"
+      />
+    </svg>
+  ),
+};
+
+const Icon = ({ name, className = '' }: IconProps) => (
+  <span className={className}>{icons[name] || null}</span>
+);
+
+export default Icon;

--- a/src/data/blog-posts/hello-world.md
+++ b/src/data/blog-posts/hello-world.md
@@ -1,0 +1,6 @@
+---
+title: "Hello World"
+date: "2023-01-01"
+---
+
+Welcome to GrowLab's very first post!

--- a/src/data/products.json
+++ b/src/data/products.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "ai-writer",
+    "name": "AI Writer",
+    "price": "$19",
+    "description": "Generate marketing copy in seconds."
+  },
+  {
+    "id": "waas-starter",
+    "name": "WaaS Starter",
+    "price": "$49/mo",
+    "description": "Beautiful 5-page website with hosting included."
+  },
+  {
+    "id": "automation-kit",
+    "name": "Automation Kit",
+    "price": "$29",
+    "description": "Collection of ready-to-use Power Automate flows."
+  }
+]

--- a/src/data/testimonials.json
+++ b/src/data/testimonials.json
@@ -1,0 +1,14 @@
+[
+  {
+    "author": "Jane Doe",
+    "quote": "GrowLab helped us automate tedious tasks and focus on real growth."
+  },
+  {
+    "author": "John Smith",
+    "quote": "Our website looks amazing and converts visitors like crazy."
+  },
+  {
+    "author": "Lisa Wong",
+    "quote": "The Power Automate templates saved us countless hours."
+  }
+]

--- a/src/pages/blog/index.tsx
+++ b/src/pages/blog/index.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { Link, graphql } from 'gatsby';
+import Header from '../../components/layout/Header';
+import Footer from '../../components/layout/Footer';
+import Container from '../../components/shared/Container';
+
+const BlogIndex = ({ data }: any) => (
+  <>
+    <Header />
+    <main className="py-16 bg-gray-50">
+      <Container>
+        <h1 className="text-3xl font-extrabold text-gray-900 mb-8">Blog</h1>
+        <ul className="space-y-6">
+          {data.allMarkdownRemark.nodes.map((post: any) => (
+            <li key={post.fields.slug}>
+              <Link to={post.fields.slug} className="text-blue-600 hover:underline">
+                {post.frontmatter.title}
+              </Link>
+              <p className="text-sm text-gray-600">{post.frontmatter.date}</p>
+            </li>
+          ))}
+        </ul>
+      </Container>
+    </main>
+    <Footer />
+  </>
+);
+
+export const pageQuery = graphql`
+  query BlogIndexQuery {
+    allMarkdownRemark(sort: {frontmatter: {date: DESC}}) {
+      nodes {
+        frontmatter {
+          title
+          date(formatString: "MMMM DD, YYYY")
+        }
+        fields {
+          slug
+        }
+      }
+    }
+  }
+`;
+
+export default BlogIndex;

--- a/src/pages/contact.tsx
+++ b/src/pages/contact.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import Header from '../components/layout/Header';
+import Footer from '../components/layout/Footer';
+import Container from '../components/shared/Container';
+import Button from '../components/ui/Button';
+
+const ContactPage = () => (
+  <>
+    <Header />
+    <main className="py-16">
+      <Container className="max-w-lg">
+        <h1 className="text-3xl font-extrabold text-gray-900 mb-8">Contact Us</h1>
+        <form className="space-y-4">
+          <input
+            type="text"
+            placeholder="Name"
+            className="w-full rounded-md border-gray-300 px-4 py-2 focus:border-blue-500 focus:ring-blue-500"
+          />
+          <input
+            type="email"
+            placeholder="Email"
+            className="w-full rounded-md border-gray-300 px-4 py-2 focus:border-blue-500 focus:ring-blue-500"
+          />
+          <textarea
+            placeholder="How can we help?"
+            className="w-full rounded-md border-gray-300 px-4 py-2 focus:border-blue-500 focus:ring-blue-500"
+          />
+          <Button type="submit">Send Message</Button>
+        </form>
+      </Container>
+    </main>
+    <Footer />
+  </>
+);
+
+export default ContactPage;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import Header from '../components/layout/Header';
+import Footer from '../components/layout/Footer';
+import Hero from '../components/sections/Hero';
+import FeatureGrid from '../components/sections/FeatureGrid';
+import PricingTable from '../components/sections/PricingTable';
+import Testimonials from '../components/sections/Testimonials';
+import CallToAction from '../components/sections/CallToAction';
+
+const IndexPage = () => (
+  <>
+    <Header />
+    <main>
+      <Hero />
+      <FeatureGrid />
+      <PricingTable />
+      <Testimonials />
+      <CallToAction />
+    </main>
+    <Footer />
+  </>
+);
+
+export default IndexPage;

--- a/src/pages/products.tsx
+++ b/src/pages/products.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import Header from '../components/layout/Header';
+import Footer from '../components/layout/Footer';
+import Container from '../components/shared/Container';
+import Card from '../components/ui/Card';
+import Button from '../components/ui/Button';
+import products from '../data/products.json';
+
+const ProductsPage = () => (
+  <>
+    <Header />
+    <main className="py-16 bg-gray-50">
+      <Container>
+        <h1 className="text-3xl font-extrabold text-gray-900 mb-8">Products</h1>
+        <div className="grid gap-8 md:grid-cols-3">
+          {products.map((p) => (
+            <Card key={p.id} title={p.name}>
+              <p className="mt-2 text-gray-600">{p.description}</p>
+              <p className="mt-4 text-lg font-semibold">{p.price}</p>
+              <Button className="mt-4 w-full">Buy Now</Button>
+            </Card>
+          ))}
+        </div>
+      </Container>
+    </main>
+    <Footer />
+  </>
+);
+
+export default ProductsPage;

--- a/src/pages/website-plans.tsx
+++ b/src/pages/website-plans.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import Header from '../components/layout/Header';
+import Footer from '../components/layout/Footer';
+import PricingTable from '../components/sections/PricingTable';
+
+const WebsitePlansPage = () => (
+  <>
+    <Header />
+    <main>
+      <PricingTable />
+    </main>
+    <Footer />
+  </>
+);
+
+export default WebsitePlansPage;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,0 +1,1 @@
+@import '../components/layout/GlobalStyles.css';

--- a/src/templates/blog-post.tsx
+++ b/src/templates/blog-post.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { graphql } from 'gatsby';
+import Header from '../components/layout/Header';
+import Footer from '../components/layout/Footer';
+import Container from '../components/shared/Container';
+
+const BlogPostTemplate = ({ data }: any) => {
+  const post = data.markdownRemark;
+  return (
+    <>
+      <Header />
+      <main className="py-16 bg-white">
+        <Container className="prose mx-auto">
+          <h1>{post.frontmatter.title}</h1>
+          <p className="text-sm text-gray-500">{post.frontmatter.date}</p>
+          <div dangerouslySetInnerHTML={{ __html: post.html }} />
+        </Container>
+      </main>
+      <Footer />
+    </>
+  );
+};
+
+export const pageQuery = graphql`
+  query BlogPostBySlug($slug: String!) {
+    markdownRemark(fields: { slug: { eq: $slug } }) {
+      html
+      frontmatter {
+        title
+        date(formatString: "MMMM DD, YYYY")
+      }
+    }
+  }
+`;
+
+export default BlogPostTemplate;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ['./src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "jsx": "react",
+    "strict": true,
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- build foundational UI components and layout
- implement landing sections and basic pages
- add blog support with sample post
- configure Tailwind, Gatsby, and TypeScript

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688106223f74832f99370f88d1112285