### PR TITLE
Fix Gatsby dependencies and ignore build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.cache/
+public/
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -8,13 +8,16 @@
   },
   "dependencies": {
     "gatsby": "^5.0.0",
+    "gatsby-plugin-postcss": "^6.14.0",
+    "gatsby-source-filesystem": "^5.14.0",
+    "gatsby-transformer-remark": "^6.14.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
   },
   "devDependencies": {
-    "tailwindcss": "^3.0.0",
-    "postcss": "^8.0.0",
     "autoprefixer": "^10.0.0",
+    "postcss": "^8.0.0",
+    "tailwindcss": "^3.0.0",
     "typescript": "^4.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- add missing Gatsby plugins so the site builds
- ignore generated directories

## Testing
- `npm test`
- `npm run build`
- `npm run develop` (then `Ctrl+C`)


------
https://chatgpt.com/codex/tasks/task_e_68810a17f9e8832fa64963d9d8a365b0