### PR TITLE
Add responsive mobile menu

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,23 +1,46 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Logo from '../shared/Logo';
 import Nav from './Nav';
 import Button from '../ui/Button';
 import Container from '../shared/Container';
+import Icon from '../ui/Icon';
+const Header = () => {
+  const [open, setOpen] = useState(false);
 
-const Header = () => (
-  <header className="bg-gray-900/80 backdrop-blur-sm sticky top-0 z-50">
-    <Container className="flex items-center justify-between py-4">
-      <Logo />
-      <div className="hidden md:flex flex-1 justify-center">
-        <Nav />
-      </div>
-      <div className="ml-4 hidden md:block">
-        <Button as="a" href="/contact">
-          Start a Project
-        </Button>
-      </div>
-    </Container>
-  </header>
-);
+  return (
+    <header className="bg-gray-900/80 backdrop-blur-sm sticky top-0 z-50">
+      <Container className="flex items-center justify-between py-4">
+        <Logo />
+        <div className="hidden md:flex flex-1 justify-center">
+          <Nav />
+        </div>
+        <div className="ml-4 hidden md:block">
+          <Button as="a" href="/contact">
+            Start a Project
+          </Button>
+        </div>
+        <button
+          className="md:hidden text-gray-400 hover:text-white focus:outline-none"
+          onClick={() => setOpen(!open)}
+          aria-label="Toggle menu"
+        >
+          <Icon name={open ? 'close' : 'menu'} />
+        </button>
+      </Container>
+      {open && (
+        <div className="md:hidden border-t border-gray-800">
+          <Container className="py-4">
+            <Nav vertical onNavigate={() => setOpen(false)} />
+            <div className="mt-4">
+              <Button as="a" href="/contact" className="w-full" onClick={() => setOpen(false)}>
+                Start a Project
+              </Button>
+            </div>
+          </Container>
+        </div>
+      )}
+    </header>
+  );
+};
 
 export default Header;

--- a/src/components/layout/Nav.tsx
+++ b/src/components/layout/Nav.tsx
@@ -8,13 +8,23 @@ const links = [
   { to: '/contact', label: 'Contact' },
 ];
 
-const Nav = () => (
-  <nav className="space-x-10 text-sm font-medium text-gray-400">
+interface NavProps {
+  vertical?: boolean;
+  onNavigate?: () => void;
+}
+
+const Nav = ({ vertical = false, onNavigate }: NavProps) => (
+  <nav
+    className={`${
+      vertical ? 'flex flex-col space-y-4 text-center' : 'space-x-10'
+    } text-sm font-medium text-gray-400`}
+  >
     {links.map((link) => (
       <Link
         key={link.to}
         to={link.to}
         className="transition-colors hover:text-white"
+        onClick={onNavigate}
       >
         {link.label}
       </Link>

--- a/src/components/ui/Icon.tsx
+++ b/src/components/ui/Icon.tsx
@@ -15,6 +15,24 @@ const icons: Record<string, JSX.Element> = {
       />
     </svg>
   ),
+  menu: (
+    <svg viewBox="0 0 24 24" fill="currentColor" className="h-6 w-6">
+      <path
+        fillRule="evenodd"
+        d="M3 6a1 1 0 011-1h16a1 1 0 110 2H4a1 1 0 01-1-1zm0 6a1 1 0 011-1h16a1 1 0 110 2H4a1 1 0 01-1-1zm1 5a1 1 0 000 2h16a1 1 0 100-2H4z"
+        clipRule="evenodd"
+      />
+    </svg>
+  ),
+  close: (
+    <svg viewBox="0 0 24 24" fill="currentColor" className="h-6 w-6">
+      <path
+        fillRule="evenodd"
+        d="M6.225 4.811a1 1 0 011.414 0L12 9.172l4.361-4.361a1 1 0 111.414 1.414L13.414 10.586l4.361 4.361a1 1 0 01-1.414 1.414L12 12l-4.361 4.361a1 1 0 01-1.414-1.414l4.361-4.361-4.361-4.361a1 1 0 010-1.414z"
+        clipRule="evenodd"
+      />
+    </svg>
+  ),
 };
 
 const Icon = ({ name, className = '' }: IconProps) => (


### PR DESCRIPTION
## Summary
- add menu and close icons
- add vertical variant to Nav
- implement hamburger menu with state in Header

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688156ffd8ac832f941b5aaa937a73a4