### PR TITLE
Improve landing page CTA and layout

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -11,6 +11,7 @@ module.exports = {
     `gatsby-transformer-sharp`,
     `gatsby-transformer-remark`,
     `gatsby-plugin-typescript`,
+    `gatsby-plugin-react-helmet`,
     {
       resolve: `gatsby-source-filesystem`,
       options: {

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -17,7 +17,7 @@ const Header = () => {
         </div>
         <div className="ml-4 hidden md:block">
           <Button variant="primary" size="large" as="a" href="/contact">
-            Start a Project
+            Get Quote
           </Button>
         </div>
         <button
@@ -41,7 +41,7 @@ const Header = () => {
                 href="/contact"
                 onClick={() => setOpen(false)}
               >
-                Start a Project
+                Get Quote
               </Button>
             </div>
           </Container>

--- a/src/components/sections/FeatureGrid.tsx
+++ b/src/components/sections/FeatureGrid.tsx
@@ -41,6 +41,7 @@ const features = [
 const FeatureGrid = () => (
   <section id="features" className="py-20 bg-primary/10">
     <Container>
+      <h2 className="text-3xl text-center mb-12">What We Offer</h2>
       <div className="grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
         {features.map((feature) => (
           <div key={feature.title} className="flex items-start space-x-4">

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -3,7 +3,7 @@ import Button from '../ui/Button';
 import Container from '../shared/Container';
 
 const Hero = () => (
-  <section className="py-32 text-center">
+  <section className="py-32 text-center bg-gradient-to-b from-gray-900 via-gray-800 to-gray-900">
     <Container>
       <h1 className="mx-auto max-w-4xl text-5xl tracking-tighter sm:text-7xl">
         Transforming Digital Ambition into Reality.
@@ -13,11 +13,11 @@ const Hero = () => (
         cutting-edge AI tools, bespoke websites, and powerful automation solutions.
       </p>
       <div className="mt-10 flex justify-center space-x-4">
-        <Button size="large" as="a" href="/products">
-          Discover Solutions
+        <Button size="xl" as="a" href="/contact">
+          Get a Free Consultation
         </Button>
-        <Button size="large" variant="secondary" as="a" href="/contact">
-          Start a Project
+        <Button size="xl" variant="secondary" as="a" href="/products">
+          Explore Services
         </Button>
       </div>
     </Container>

--- a/src/components/sections/Portfolio.tsx
+++ b/src/components/sections/Portfolio.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import Container from '../shared/Container';
+
+const projects = [
+  {
+    title: 'Sheffield Collision',
+    img: 'https://via.placeholder.com/300x200?text=Sheffield+Collision',
+  },
+  {
+    title: 'Upright Medical',
+    img: 'https://via.placeholder.com/300x200?text=Upright+Medical',
+  },
+  {
+    title: 'Example Startup',
+    img: 'https://via.placeholder.com/300x200?text=Startup+Site',
+  },
+];
+
+const Portfolio = () => (
+  <section className="py-20">
+    <Container>
+      <h2 className="text-3xl text-center mb-12">See Our Work</h2>
+      <div className="grid gap-8 md:grid-cols-3">
+        {projects.map((p) => (
+          <div key={p.title}>
+            <img src={p.img} alt={p.title} className="rounded-lg shadow-lg" />
+            <p className="mt-2 text-center text-sm text-gray-400">{p.title}</p>
+          </div>
+        ))}
+      </div>
+    </Container>
+  </section>
+);
+
+export default Portfolio;

--- a/src/components/shared/Logo.tsx
+++ b/src/components/shared/Logo.tsx
@@ -7,7 +7,7 @@ const Logo = () => (
     <img
       src={logo}
       alt="GrowLabs Logo"
-      className="h-32 w-auto"
+      className="h-20 w-auto sm:h-28 lg:h-32"
     />
   </Link>
 );

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -2,7 +2,7 @@ import React, { ElementType } from 'react';
 
 interface ButtonProps {
   variant?: 'primary' | 'secondary';
-  size?: 'normal' | 'large';
+  size?: 'normal' | 'large' | 'xl';
   as?: ElementType;
   children: React.ReactNode;
   [x: string]: any;
@@ -19,6 +19,7 @@ const variants = {
 const sizes = {
   normal: 'px-6 py-3 text-sm',
   large: 'px-8 py-4 text-base',
+  xl: 'px-10 py-5 text-lg sm:text-xl',
 };
 
 const Button: React.FC<ButtonProps> = ({

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Helmet } from 'react-helmet';
 import Header from '../components/layout/Header';
 import Footer from '../components/layout/Footer';
 import Hero from '../components/sections/Hero';
@@ -6,13 +7,27 @@ import FeatureGrid from '../components/sections/FeatureGrid';
 import PricingTable from '../components/sections/PricingTable';
 import Testimonials from '../components/sections/Testimonials';
 import CallToAction from '../components/sections/CallToAction';
+import Portfolio from '../components/sections/Portfolio';
 
 const IndexPage = () => (
   <>
+    <Helmet>
+      <title>GrowLab - Build, Automate, Grow</title>
+      <meta
+        name="description"
+        content="GrowLab helps you build websites, automate workflows and leverage AI tools to grow your business."
+      />
+      <meta property="og:title" content="GrowLab" />
+      <meta
+        property="og:description"
+        content="Digital products and automation templates for scaling modern businesses."
+      />
+    </Helmet>
     <Header />
     <main>
       <Hero />
       <FeatureGrid />
+      <Portfolio />
       <PricingTable />
       <Testimonials />
       <CallToAction />


### PR DESCRIPTION
## Summary
- make hero section more prominent with gradient background and larger buttons
- tweak header CTA button text
- add a new Portfolio section
- include meta tags using `react-helmet`
- add "What We Offer" heading
- adjust logo scaling
- support extra large button size
- register `gatsby-plugin-react-helmet`

## Testing
- `npm test`
- `npm run build` *(fails: gatsby Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_6881997f1984832fa2880e88dad65dfa