### PR TITLE
Switch site font to Satoshi

### DIFF
--- a/src/components/layout/GlobalStyles.css
+++ b/src/components/layout/GlobalStyles.css
@@ -1,5 +1,5 @@
-/* Import Google Fonts first */
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700;800&display=swap');
+/* Import Satoshi font from Fontshare */
+@import url('https://api.fontshare.com/v2/css?f[]=satoshi@400,500,700,800&display=swap');
 
 /* Then, include Tailwind's base, component, and utility styles */
 @tailwind base;
@@ -8,7 +8,7 @@
 
 /* Now, apply your custom base styles for the dark theme */
 html {
-  font-family: 'Inter', sans-serif;
+  font-family: 'Satoshi', sans-serif;
   scroll-behavior: smooth;
 }
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,7 +6,7 @@ module.exports = {
   theme: {
     extend: {
       fontFamily: {
-        sans: ['Inter', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+        sans: ['Satoshi', 'ui-sans-serif', 'system-ui', 'sans-serif'],
       },
       colors: {
         primary: "#0A2640", // Dark blue 


### PR DESCRIPTION
## Summary
- load Satoshi from Fontshare
- set Satoshi as the default sans font in Tailwind

## Testing
- `npm test`
- `gatsby build` *(fails: No native build was found for platform=linux arch=x64 runtime=node)*

------
https://chatgpt.com/codex/tasks/task_e_6882621850c4832faa796b8b2cce1717