### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -44,8 +44,8 @@ const Header = () => {
       </Container>
 
       {open && (
-        <div className="md:hidden fixed inset-0 z-40 bg-gray-900/90 backdrop-blur-sm">
-          <Container className="py-8">
+        <div className="md:hidden fixed inset-0 z-40 bg-gray-900/90 backdrop-blur-sm animate-fade-in">
+          <Container className="py-8 animate-slide-down">
             <Nav vertical onNavigate={() => setOpen(false)} />
             <div className="mt-8 flex justify-center">
               <Button

--- a/src/components/sections/FeatureGrid.tsx
+++ b/src/components/sections/FeatureGrid.tsx
@@ -69,7 +69,7 @@ const FeatureGrid = () => (
   <section id="features" className="py-32 bg-primary/10">
     <Container>
       <h2 className="text-3xl text-center mb-12">What We Offer</h2>
-      <div className="grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
+      <div className="grid grid-cols-2 gap-6 sm:grid-cols-3 lg:grid-cols-4">
         {features.map(({ title, description, href, icon: IconComponent }) => (
           <Link key={title} to={href} className="group block transform transition-transform hover:-translate-y-1">
             <Card title={title} className="h-full text-center">

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -38,16 +38,16 @@ const Hero = () => {
 
       {/* Content */}
       <div className="relative z-20">
-        <Container className="py-24 sm:py-32">
+        <Container className="py-16 sm:py-32">
           {/* ... (no changes to h1 and p tags) ... */}
           <h1
-            className="mx-auto max-w-4xl animate-fade-in-up bg-gradient-to-br from-white to-gray-400 bg-clip-text text-5xl font-bold tracking-tighter text-transparent sm:text-7xl"
+            className="mx-auto max-w-4xl animate-fade-in-up bg-gradient-to-br from-white to-gray-400 bg-clip-text text-4xl font-bold tracking-tighter text-transparent sm:text-6xl"
             style={{ animationDelay: '0.2s', animationFillMode: 'forwards' }}
           >
             Transforming Digital Ambition into Reality.
           </h1>
           <p
-            className="mx-auto mt-6 max-w-2xl animate-fade-in-up text-lg text-gray-300"
+            className="mx-auto mt-6 max-w-2xl animate-fade-in-up text-base text-gray-300 sm:text-lg"
             style={{ animationDelay: '0.4s', animationFillMode: 'forwards', opacity: 0 }}
           >
             We partner with you to build, automate, and grow your business with

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -15,6 +15,8 @@ module.exports = {
       // New animation and keyframes added below
       animation: {
         'fade-in-up': 'fade-in-up 0.8s ease-out forwards',
+        'fade-in': 'fade-in 0.3s ease-out forwards',
+        'slide-down': 'slide-down 0.3s ease-out forwards',
       },
       keyframes: {
         'fade-in-up': {
@@ -26,6 +28,14 @@ module.exports = {
             opacity: '1',
             transform: 'translateY(0)',
           },
+        },
+        'fade-in': {
+          '0%': { opacity: '0' },
+          '100%': { opacity: '1' },
+        },
+        'slide-down': {
+          '0%': { transform: 'translateY(-10%)', opacity: '0' },
+          '100%': { transform: 'translateY(0)', opacity: '1' },
         },
       },
     },


### PR DESCRIPTION
## Summary
- add fade-in and slide-down animations in tailwind config
- animate the mobile nav overlay
- tweak hero heading size and padding for small screens
- allow feature grid to show two columns on mobile

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688273d980a8832f8113bd28f5592b08