### PR TITLE
Improve typography and highlight CTA

### DIFF
--- a/src/components/layout/GlobalStyles.css
+++ b/src/components/layout/GlobalStyles.css
@@ -1,5 +1,7 @@
 /* Import Satoshi font from Fontshare */
 @import url('https://api.fontshare.com/v2/css?f[]=satoshi@400,500,700,800&display=swap');
+/* Import Playfair Display for headings */
+@import url('https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&display=swap');
 
 /* Then, include Tailwind's base, component, and utility styles */
 @tailwind base;
@@ -18,8 +20,8 @@ body {
 }
 
 h1, h2, h3, h4, h5, h6 {
-  /* Make all headings bold and white for contrast */
-  @apply font-extrabold text-white;
+  /* Use serif font for headings and keep them bold */
+  @apply font-serif font-extrabold text-white;
 }
 
 /* Add styles for blog post content on a dark background */

--- a/src/components/sections/CallToAction.tsx
+++ b/src/components/sections/CallToAction.tsx
@@ -3,8 +3,8 @@ import Button from '../ui/Button';
 import Container from '../shared/Container';
 
 const CallToAction = () => (
-  <section className="py-24 text-center">
-    <Container>
+  <section className="py-24 text-center bg-primary">
+    <Container className="text-white">
       <h2 className="text-4xl">Ready to grow your business?</h2>
       <p className="mt-4 mb-6 text-gray-300 max-w-2xl mx-auto">
         Let's build something great together. Get in touch to discuss your project.

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -79,22 +79,19 @@ const Hero = () => {
             style={{ animationDelay: '0.8s', animationFillMode: 'forwards', opacity: 0 }}
           >
             <Button
+              variant="primary"
               size="xl"
               as="a"
               href="/contact"
-              className="group relative inline-flex items-center justify-center overflow-hidden rounded-lg border border-white/20 bg-white/10 px-8 py-3 font-medium text-white backdrop-blur-md transition-all duration-300 hover:scale-105 hover:bg-white/20 focus:outline-none focus:ring-2 focus:ring-white/50"
             >
-                <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_500px_at_50%_200px,#1e40af,transparent)] opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
-                Get a Free Consultation
+              Get a Free Consultation
             </Button>
-            {/* This button now has the same style as the one above */}
             <Button
+              variant="primary"
               size="xl"
               as="a"
               href="/products"
-              className="group relative inline-flex items-center justify-center overflow-hidden rounded-lg border border-white/20 bg-white/10 px-8 py-3 font-medium text-white backdrop-blur-md transition-all duration-300 hover:scale-105 hover:bg-white/20 focus:outline-none focus:ring-2 focus:ring-white/50"
             >
-              <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_500px_at_50%_200px,#1e40af,transparent)] opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
               Explore Services
             </Button>
           </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,6 +7,7 @@ module.exports = {
     extend: {
       fontFamily: {
         sans: ['Satoshi', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+        serif: ['"Playfair Display"', 'serif'],
       },
       colors: {
         primary: "#0A2640", // Dark blue 


### PR DESCRIPTION
## Summary
- add Playfair Display for heading font
- style h1-h6 with the new serif font
- use accent colored buttons in the hero section
- give call-to-action section a primary background

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882758b9da0832f91b07a00bc77d617