### PR TITLE
Add scroll-triggered reveal animations

### DIFF
--- a/src/components/sections/CallToAction.tsx
+++ b/src/components/sections/CallToAction.tsx
@@ -1,19 +1,26 @@
 import React from 'react';
 import Button from '../ui/Button';
 import Container from '../shared/Container';
+import Reveal from '../ui/Reveal';
 
 const CallToAction = () => (
-  <section className="py-24 text-center bg-primary">
+  <Reveal as="section" className="py-24 text-center bg-primary">
     <Container className="text-white">
-      <h2 className="text-4xl">Ready to grow your business?</h2>
-      <p className="mt-4 mb-6 text-gray-300 max-w-2xl mx-auto">
-        Let's build something great together. Get in touch to discuss your project.
-      </p>
-      <Button as="a" href="/contact" size="large">
-        Get a Free Consultation
-      </Button>
+      <Reveal>
+        <h2 className="text-4xl">Ready to grow your business?</h2>
+      </Reveal>
+      <Reveal>
+        <p className="mt-4 mb-6 text-gray-300 max-w-2xl mx-auto">
+          Let's build something great together. Get in touch to discuss your project.
+        </p>
+      </Reveal>
+      <Reveal>
+        <Button as="a" href="/contact" size="large">
+          Get a Free Consultation
+        </Button>
+      </Reveal>
     </Container>
-  </section>
+  </Reveal>
 );
 
 export default CallToAction;

--- a/src/components/sections/FeatureGrid.tsx
+++ b/src/components/sections/FeatureGrid.tsx
@@ -16,6 +16,7 @@ import {
 } from '@heroicons/react/24/outline';
 import Card from '../ui/Card';
 import Container from '../shared/Container';
+import Reveal from '../ui/Reveal';
 
 const features = [
   {
@@ -94,21 +95,23 @@ const features = [
 
 
 const FeatureGrid = () => (
-  <section id="features" className="py-32 bg-primary/10">
+  <Reveal as="section" id="features" className="py-32 bg-primary/10">
     <Container>
       <h2 className="text-3xl text-center mb-12">What We Offer</h2>
       <div className="grid grid-cols-2 gap-6 sm:grid-cols-3 lg:grid-cols-4">
         {features.map(({ title, description, href, icon: IconComponent }) => (
-          <Link key={title} to={href} className="group block transform transition-transform hover:-translate-y-1">
-            <Card title={title} className="h-full text-center">
-              <IconComponent className="mx-auto mb-4 h-8 w-8 text-accent" />
-              <p className="text-gray-300">{description}</p>
-            </Card>
-          </Link>
+          <Reveal key={title} className="group block">
+            <Link to={href} className="transform transition-transform hover:-translate-y-1 block">
+              <Card title={title} className="h-full text-center">
+                <IconComponent className="mx-auto mb-4 h-8 w-8 text-accent" />
+                <p className="text-gray-300">{description}</p>
+              </Card>
+            </Link>
+          </Reveal>
         ))}
       </div>
     </Container>
-  </section>
+  </Reveal>
 );
 
 export default FeatureGrid;

--- a/src/components/sections/Portfolio.tsx
+++ b/src/components/sections/Portfolio.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Container from '../shared/Container';
+import Reveal from '../ui/Reveal';
 // 👇 Import the JSON file directly
 import projectsData from '../shared/portfolio.json';
 // Define a type for a single project object for type safety
@@ -14,30 +15,31 @@ interface Project {
 const projects: Project[] = projectsData;
 
 const Portfolio: React.FC = () => (
-  <section className="py-20 bg-primary/10">
+  <Reveal as="section" className="py-20 bg-primary/10">
     <Container>
       <h2 className="text-4xl font-bold text-center mb-16">See Our Work</h2>
       <div className="grid gap-10 md:grid-cols-2 lg:grid-cols-3">
         {projects.map((project) => (
-          <a
-            key={project.name}
-            href={project.url}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="block group rounded-lg bg-gray-800/50 border border-gray-700 p-6 transform hover:-translate-y-2 transition-transform duration-300"
-          >
-            <img
-              src={project.logo}
-              alt={`${project.name} logo`}
-              className="w-full h-48 object-contain mb-4"
-            />
-            <h3 className="text-xl font-semibold mb-2 text-white">{project.name}</h3>
-            <p className="text-sm text-gray-300">{project.description}</p>
-          </a>
+          <Reveal key={project.name} className="block">
+            <a
+              href={project.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="group rounded-lg bg-gray-800/50 border border-gray-700 p-6 transform hover:-translate-y-2 transition-transform duration-300 block"
+            >
+              <img
+                src={project.logo}
+                alt={`${project.name} logo`}
+                className="w-full h-48 object-contain mb-4"
+              />
+              <h3 className="text-xl font-semibold mb-2 text-white">{project.name}</h3>
+              <p className="text-sm text-gray-300">{project.description}</p>
+            </a>
+          </Reveal>
         ))}
       </div>
     </Container>
-  </section>
+  </Reveal>
 );
 
 export default Portfolio;

--- a/src/components/sections/PricingTable.tsx
+++ b/src/components/sections/PricingTable.tsx
@@ -3,6 +3,7 @@ import Card from '../ui/Card';
 import Button from '../ui/Button';
 import Container from '../shared/Container';
 import Icon from '../ui/Icon';
+import Reveal from '../ui/Reveal';
 
 const plans = [
   {
@@ -59,7 +60,7 @@ const plans = [
 ];
 
 const PricingTable = () => (
-  <section className="bg-primary/10 py-20">
+  <Reveal as="section" className="bg-primary/10 py-20">
     <Container>
       <h2 className="text-3xl text-center mb-4">GrowLab Business Launch Plans</h2>
       <p className="mx-auto mb-12 max-w-2xl text-center text-gray-300">
@@ -69,19 +70,21 @@ const PricingTable = () => (
       </p>
       <div className="grid gap-8 md:grid-cols-3">
         {plans.map((plan) => (
-          <Card key={plan.name} title={plan.name} className="text-center">
-            <p className="mt-2 text-4xl">{plan.price}</p>
-            <ul className="mt-6 space-y-3 text-sm text-gray-300">
-              {plan.features.map((f) => (
-                <li key={f} className="flex items-center justify-center space-x-2">
-                  <Icon name="check" className="text-accent h-4 w-4" />
-                  <span>{f}</span>
-                </li>
-              ))}
-            </ul>
-            <p className="mt-4 text-sm italic text-gray-400">{plan.tagline}</p>
-            <Button className="mt-8 w-full">Choose Plan</Button>
-          </Card>
+          <Reveal key={plan.name}>
+            <Card title={plan.name} className="text-center">
+              <p className="mt-2 text-4xl">{plan.price}</p>
+              <ul className="mt-6 space-y-3 text-sm text-gray-300">
+                {plan.features.map((f) => (
+                  <li key={f} className="flex items-center justify-center space-x-2">
+                    <Icon name="check" className="text-accent h-4 w-4" />
+                    <span>{f}</span>
+                  </li>
+                ))}
+              </ul>
+              <p className="mt-4 text-sm italic text-gray-400">{plan.tagline}</p>
+              <Button className="mt-8 w-full">Choose Plan</Button>
+            </Card>
+          </Reveal>
         ))}
       </div>
       <div className="mx-auto mt-16 max-w-2xl text-sm text-gray-300">
@@ -108,7 +111,7 @@ const PricingTable = () => (
         </ul>
       </div>
     </Container>
-  </section>
+  </Reveal>
 );
 
 export default PricingTable;

--- a/src/components/sections/Testimonials.tsx
+++ b/src/components/sections/Testimonials.tsx
@@ -1,21 +1,24 @@
 import React from 'react';
 import Container from '../shared/Container';
 import Card from '../ui/Card';
+import Reveal from '../ui/Reveal';
 import testimonials from '../../data/testimonials.json';
 
 const Testimonials = () => (
-  <section id="testimonials" className="py-20">
+  <Reveal as="section" id="testimonials" className="py-20">
     <Container>
       <h2 className="text-3xl text-center mb-12">Trusted by builders at companies everywhere</h2>
       <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
         {testimonials.map((t) => (
-          <Card key={t.author} title={t.author}>
-            <p className="text-gray-300">"{t.quote}"</p>
-          </Card>
+          <Reveal key={t.author}>
+            <Card title={t.author}>
+              <p className="text-gray-300">"{t.quote}"</p>
+            </Card>
+          </Reveal>
         ))}
       </div>
     </Container>
-  </section>
+  </Reveal>
 );
 
 export default Testimonials;

--- a/src/components/ui/Reveal.tsx
+++ b/src/components/ui/Reveal.tsx
@@ -1,0 +1,19 @@
+import React, { ReactNode, ElementType } from 'react';
+import useScrollReveal from '../../hooks/useScrollReveal';
+
+interface RevealProps {
+  as?: ElementType;
+  children: ReactNode;
+  className?: string;
+}
+
+const Reveal: React.FC<RevealProps> = ({ as: Component = 'div', children, className = '' }) => {
+  const ref = useScrollReveal();
+  return (
+    <Component ref={ref} className={`opacity-0 translate-y-6 ${className}`}>
+      {children}
+    </Component>
+  );
+};
+
+export default Reveal;

--- a/src/hooks/useScrollReveal.ts
+++ b/src/hooks/useScrollReveal.ts
@@ -1,0 +1,32 @@
+import { useEffect, useRef } from 'react';
+
+export default function useScrollReveal<T extends HTMLElement>(threshold: number = 0.1) {
+  const ref = useRef<T>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    if (reduceMotion) {
+      el.classList.remove('opacity-0', 'translate-y-6');
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          el.classList.add('animate-fade-in-up');
+          observer.unobserve(entry.target);
+        }
+      },
+      { threshold }
+    );
+
+    observer.observe(el);
+
+    return () => observer.disconnect();
+  }, [threshold]);
+
+  return ref;
+}


### PR DESCRIPTION
## Summary
- add generic `Reveal` component and `useScrollReveal` hook
- apply reveal animations to multiple sections so they fade in on scroll

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688277865d20832f899a02eae16bdda9