### PR TITLE
Improve call to action links

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -31,7 +31,7 @@ const Header = () => {
         </div>
         <div className="ml-4 hidden md:block">
           <Button variant="primary" size="large" as="a" href="/contact">
-            Get a Free Consultation
+            Book Your Free Strategy Session
           </Button>
         </div>
         <button
@@ -55,7 +55,7 @@ const Header = () => {
                 href="/contact"
                 onClick={() => setOpen(false)}
               >
-                Get a Free Consultation
+                Book Your Free Strategy Session
               </Button>
             </div>
           </Container>

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -84,13 +84,13 @@ const Hero = () => {
               as="a"
               href="/contact"
             >
-              Get a Free Consultation
+              Book Your Free Strategy Session
             </Button>
             <Button
               variant="primary"
               size="xl"
               as="a"
-              href="/products"
+              href="/#features"
             >
               Explore Services
             </Button>

--- a/src/components/sections/PricingTable.tsx
+++ b/src/components/sections/PricingTable.tsx
@@ -82,7 +82,13 @@ const PricingTable = () => (
                 ))}
               </ul>
               <p className="mt-4 text-sm italic text-gray-400">{plan.tagline}</p>
-              <Button className="mt-8 w-full">Choose Plan</Button>
+              <Button
+                className="mt-8 w-full"
+                as="a"
+                href={`/contact?plan=${plan.name}`}
+              >
+                Choose Plan
+              </Button>
             </Card>
           </Reveal>
         ))}


### PR DESCRIPTION
## Summary
- update hero CTA label and link to features
- unify header CTA wording
- make pricing CTA link to contact page with plan selected

## Testing
- `npm test`
- `npx gatsby build` *(fails: No native build found for LMDB)*

------
https://chatgpt.com/codex/tasks/task_e_6882796d8024832f856996284ee6f5d1