### PR TITLE
Add global background glow

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import './src/styles/global.css';
 import BackgroundGlow from './src/components/layout/BackgroundGlow';
+import './src/styles/global.css';
 
 export const wrapPageElement = ({ element }) => (
   <>

--- a/src/components/layout/BackgroundGlow.tsx
+++ b/src/components/layout/BackgroundGlow.tsx
@@ -1,0 +1,31 @@
+import React, { useState, useEffect } from 'react';
+
+/**
+ * BackgroundGlow renders the radial mouse-following glow that
+ * was originally used in the Hero section. It is positioned
+ * fixed and stretched across the viewport so it can act as a
+ * site-wide background effect.
+ */
+const BackgroundGlow: React.FC = () => {
+  const [mousePosition, setMousePosition] = useState({ x: 0, y: 0 });
+
+  useEffect(() => {
+    const handleMouseMove = (event: MouseEvent) => {
+      setMousePosition({ x: event.clientX, y: event.clientY });
+    };
+
+    window.addEventListener('mousemove', handleMouseMove);
+    return () => window.removeEventListener('mousemove', handleMouseMove);
+  }, []);
+
+  return (
+    <div
+      className="pointer-events-none fixed inset-0 -z-10 transition duration-300"
+      style={{
+        background: `radial-gradient(600px circle at ${mousePosition.x}px ${mousePosition.y}px, rgba(29, 78, 216, 0.15), transparent 80%)`,
+      }}
+    />
+  );
+};
+
+export default BackgroundGlow;


### PR DESCRIPTION
## Summary
- add `BackgroundGlow` component with mouse-following radial gradient
- include the glow globally via `wrapPageElement` in both browser and SSR entry files

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882a5cc1cc8832fa6bb4f9462b85976