### PR TITLE
Match hero background globally

### DIFF
--- a/src/components/layout/BackgroundGlow.tsx
+++ b/src/components/layout/BackgroundGlow.tsx
@@ -19,12 +19,18 @@ const BackgroundGlow: React.FC = () => {
   }, []);
 
   return (
-    <div
-      className="pointer-events-none fixed inset-0 -z-10 transition duration-300"
-      style={{
-        background: `radial-gradient(600px circle at ${mousePosition.x}px ${mousePosition.y}px, rgba(29, 78, 216, 0.15), transparent 80%)`,
-      }}
-    />
+    <div className="pointer-events-none fixed inset-0 -z-10">
+      <div
+        className="absolute inset-0 transition duration-300"
+        style={{
+          background: `radial-gradient(600px circle at ${mousePosition.x}px ${mousePosition.y}px, rgba(29, 78, 216, 0.15), transparent 80%)`,
+        }}
+      />
+      <div className="absolute inset-0 z-0 opacity-40">
+        <div className="absolute inset-0 bg-[url('/grid.svg')] bg-center [mask-image:linear-gradient(180deg,white,rgba(255,255,255,0))]" />
+        <div className="absolute inset-x-0 h-[600px] bg-[radial-gradient(circle_500px_at_50%_200px,#3e3e70,transparent)]" />
+      </div>
+    </div>
   );
 };
 


### PR DESCRIPTION
## Summary
- apply hero section's grid overlay and radial gradient site-wide via `BackgroundGlow`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882a80129d8832f89d80c0a5ae50e10