### PR TITLE
Apply hero style to all sections

### DIFF
--- a/src/components/sections/CallToAction.tsx
+++ b/src/components/sections/CallToAction.tsx
@@ -2,9 +2,10 @@ import React from 'react';
 import Button from '../ui/Button';
 import Container from '../shared/Container';
 import Reveal from '../ui/Reveal';
+import StyledSection from './StyledSection';
 
 const CallToAction = () => (
-  <Reveal as="section" className="py-24 text-center bg-primary">
+  <StyledSection className="py-24 text-center">
     <Container className="text-white">
       <Reveal>
         <h2 className="text-4xl">Ready to grow your business?</h2>
@@ -20,7 +21,7 @@ const CallToAction = () => (
         </Button>
       </Reveal>
     </Container>
-  </Reveal>
+  </StyledSection>
 );
 
 export default CallToAction;

--- a/src/components/sections/FeatureGrid.tsx
+++ b/src/components/sections/FeatureGrid.tsx
@@ -17,6 +17,7 @@ import {
 import Card from '../ui/Card'; // Assuming Card component exists
 import Container from '../shared/Container';
 import Reveal from '../ui/Reveal';
+import StyledSection from './StyledSection';
 
 // No changes needed to the features array
 const features = [
@@ -95,7 +96,7 @@ const features = [
 ];
 
 const FeatureGrid = () => (
-  <Reveal as="section" id="features" className="py-32 bg-primary/10">
+  <StyledSection id="features" className="py-32">
     <Container>
       <h2 className="text-4xl font-bold text-center mb-4">What We Offer</h2>
       <p className="text-lg text-gray-400 text-center mb-16 max-w-2xl mx-auto">
@@ -130,7 +131,7 @@ const FeatureGrid = () => (
         ))}
       </div>
     </Container>
-  </Reveal>
+  </StyledSection>
 );
 
 export default FeatureGrid;

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -1,40 +1,11 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import HeroSection from './HeroSection';
+import StyledSection from './StyledSection';
 
-const Hero = () => {
-  const [mousePosition, setMousePosition] = useState({ x: 0, y: 0 });
-
-  useEffect(() => {
-    const handleMouseMove = (event: MouseEvent) => {
-      setMousePosition({ x: event.clientX, y: event.clientY });
-    };
-
-    window.addEventListener('mousemove', handleMouseMove);
-    return () => window.removeEventListener('mousemove', handleMouseMove);
-  }, []);
-
-  return (
-    <section className="relative w-full overflow-hidden bg-gray-900 text-white">
-      {/* 🔵 Dynamic background glow (fixed to stretch full height) */}
-      <div
-        className="pointer-events-none absolute inset-0 z-10 transition duration-300"
-        style={{
-          background: `radial-gradient(600px circle at ${mousePosition.x}px ${mousePosition.y}px, rgba(29, 78, 216, 0.15), transparent 80%)`,
-        }}
-      />
-
-      {/* 🔵 Grid and radial lighting pattern */}
-      <div className="absolute inset-0 z-0 opacity-40">
-        <div className="absolute inset-0 bg-[url('/grid.svg')] bg-center [mask-image:linear-gradient(180deg,white,rgba(255,255,255,0))]" />
-        <div className="absolute inset-x-0 h-[600px] bg-[radial-gradient(circle_500px_at_50%_200px,#3e3e70,transparent)]" />
-      </div>
-
-      {/* 🔵 Content wrapper — MAKE SURE THIS HAS SPACE */}
-      <div className="relative z-20 pb-32">
-        <HeroSection variant="uvpLed" />
-      </div>
-    </section>
-  );
-};
+const Hero = () => (
+  <StyledSection className="pb-32">
+    <HeroSection variant="uvpLed" />
+  </StyledSection>
+);
 
 export default Hero;

--- a/src/components/sections/Portfolio.tsx
+++ b/src/components/sections/Portfolio.tsx
@@ -3,7 +3,7 @@ import useEmblaCarousel from 'embla-carousel-react';
 import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/react/24/outline';
 
 import Container from '../shared/Container';
-import Reveal from '../ui/Reveal';
+import StyledSection from './StyledSection';
 import projectsData from '../shared/portfolio.json';
 
 // Project type remains the same
@@ -17,7 +17,13 @@ interface Project {
 const projects: Project[] = projectsData;
 
 // Reusable Arrow Button Component
-const ArrowButton = ({ enabled, onClick, children }) => (
+interface ArrowButtonProps {
+  enabled: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}
+
+const ArrowButton: React.FC<ArrowButtonProps> = ({ enabled, onClick, children }) => (
   <button
     className="h-12 w-12 rounded-full bg-gray-800/60 p-2 text-white transition hover:bg-accent disabled:opacity-30 disabled:cursor-not-allowed"
     onClick={onClick}
@@ -53,7 +59,7 @@ const Portfolio: React.FC = () => {
   }, [emblaApi, onSelect]);
 
   return (
-    <Reveal as="section" className="py-20 bg-primary/10">
+    <StyledSection className="py-20">
       <Container>
         <div className="flex flex-col items-center justify-between gap-8 md:flex-row md:gap-16">
           <div className="text-center">
@@ -102,7 +108,7 @@ const Portfolio: React.FC = () => {
           </div>
         </div>
       </Container>
-    </Reveal>
+    </StyledSection>
   );
 };
 

--- a/src/components/sections/PricingTable.tsx
+++ b/src/components/sections/PricingTable.tsx
@@ -4,6 +4,7 @@ import Button from '../ui/Button';
 import Container from '../shared/Container';
 import Icon from '../ui/Icon';
 import Reveal from '../ui/Reveal';
+import StyledSection from './StyledSection';
 
 const plans = [
   {
@@ -60,7 +61,7 @@ const plans = [
 ];
 
 const PricingTable = () => (
-  <Reveal as="section" className="bg-primary/10 py-20">
+  <StyledSection className="py-20">
     <Container>
       <h2 className="text-3xl text-center mb-4">GrowLab Business Launch Plans</h2>
       <p className="mx-auto mb-12 max-w-2xl text-center text-gray-300">
@@ -117,7 +118,7 @@ const PricingTable = () => (
         </ul>
       </div>
     </Container>
-  </Reveal>
+  </StyledSection>
 );
 
 export default PricingTable;

--- a/src/components/sections/StyledSection.tsx
+++ b/src/components/sections/StyledSection.tsx
@@ -1,0 +1,38 @@
+import React, { ReactNode, useEffect, useState } from 'react';
+
+interface StyledSectionProps {
+  children: ReactNode;
+  className?: string;
+  id?: string;
+}
+
+const StyledSection: React.FC<StyledSectionProps> = ({ children, className = '', id }) => {
+  const [mousePosition, setMousePosition] = useState({ x: 0, y: 0 });
+
+  useEffect(() => {
+    const handleMouseMove = (event: MouseEvent) => {
+      setMousePosition({ x: event.clientX, y: event.clientY });
+    };
+
+    window.addEventListener('mousemove', handleMouseMove);
+    return () => window.removeEventListener('mousemove', handleMouseMove);
+  }, []);
+
+  return (
+    <section id={id} className="relative w-full overflow-hidden bg-gray-900 text-white">
+      <div
+        className="pointer-events-none absolute inset-0 z-10 transition duration-300"
+        style={{
+          background: `radial-gradient(600px circle at ${mousePosition.x}px ${mousePosition.y}px, rgba(29, 78, 216, 0.15), transparent 80%)`,
+        }}
+      />
+      <div className="absolute inset-0 z-0 opacity-40">
+        <div className="absolute inset-0 bg-[url('/grid.svg')] bg-center [mask-image:linear-gradient(180deg,white,rgba(255,255,255,0))]" />
+        <div className="absolute inset-x-0 h-[600px] bg-[radial-gradient(circle_500px_at_50%_200px,#3e3e70,transparent)]" />
+      </div>
+      <div className={`relative z-20 ${className}`}>{children}</div>
+    </section>
+  );
+};
+
+export default StyledSection;

--- a/src/components/sections/Testimonials.tsx
+++ b/src/components/sections/Testimonials.tsx
@@ -3,9 +3,10 @@ import Container from '../shared/Container';
 import Card from '../ui/Card';
 import Reveal from '../ui/Reveal';
 import testimonials from '../../data/testimonials.json';
+import StyledSection from './StyledSection';
 
 const Testimonials = () => (
-  <Reveal as="section" id="testimonials" className="py-20">
+  <StyledSection id="testimonials" className="py-20">
     <Container>
       <h2 className="text-3xl text-center mb-12">Trusted by builders at companies everywhere</h2>
       <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
@@ -18,7 +19,7 @@ const Testimonials = () => (
         ))}
       </div>
     </Container>
-  </Reveal>
+  </StyledSection>
 );
 
 export default Testimonials;

--- a/src/components/ui/Icon.tsx
+++ b/src/components/ui/Icon.tsx
@@ -5,7 +5,7 @@ interface IconProps {
   className?: string;
 }
 
-const icons: Record<string, JSX.Element> = {
+const icons: Record<string, React.ReactElement> = {
   check: (
     <svg viewBox="0 0 20 20" fill="currentColor" className="h-5 w-5">
       <path

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,3 @@
+declare module '*.png';
+declare module '*.svg';
+declare module 'react-helmet';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "strict": true,
     "moduleResolution": "node",
     "esModuleInterop": true,
+    "resolveJsonModule": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true
   },


### PR DESCRIPTION
## Summary
- add generic `StyledSection` for shared hero background
- simplify `Hero` to use the new wrapper
- wrap all other sections with `StyledSection`
- type arrow button props and update icon types
- adjust TypeScript config and add global declarations

## Testing
- `npm test`
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6882a95617f8832fbe330bd77fcbae35