### PR TITLE
Fix glow overlap on sections

### DIFF
--- a/src/components/sections/StyledSection.tsx
+++ b/src/components/sections/StyledSection.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useEffect, useState } from 'react';
+import React, { ReactNode } from 'react';
 
 interface StyledSectionProps {
   children: ReactNode;
@@ -6,33 +6,10 @@ interface StyledSectionProps {
   id?: string;
 }
 
-const StyledSection: React.FC<StyledSectionProps> = ({ children, className = '', id }) => {
-  const [mousePosition, setMousePosition] = useState({ x: 0, y: 0 });
-
-  useEffect(() => {
-    const handleMouseMove = (event: MouseEvent) => {
-      setMousePosition({ x: event.clientX, y: event.clientY });
-    };
-
-    window.addEventListener('mousemove', handleMouseMove);
-    return () => window.removeEventListener('mousemove', handleMouseMove);
-  }, []);
-
-  return (
-    <section id={id} className="relative w-full overflow-hidden bg-gray-900 text-white">
-      <div
-        className="pointer-events-none absolute inset-0 z-10 transition duration-300"
-        style={{
-          background: `radial-gradient(600px circle at ${mousePosition.x}px ${mousePosition.y}px, rgba(29, 78, 216, 0.15), transparent 80%)`,
-        }}
-      />
-      <div className="absolute inset-0 z-0 opacity-40">
-        <div className="absolute inset-0 bg-[url('/grid.svg')] bg-center [mask-image:linear-gradient(180deg,white,rgba(255,255,255,0))]" />
-        <div className="absolute inset-x-0 h-[600px] bg-[radial-gradient(circle_500px_at_50%_200px,#3e3e70,transparent)]" />
-      </div>
-      <div className={`relative z-20 ${className}`}>{children}</div>
-    </section>
-  );
-};
+const StyledSection: React.FC<StyledSectionProps> = ({ children, className = '', id }) => (
+  <section id={id} className={`relative w-full overflow-hidden bg-gray-900 text-white ${className}`}>
+    {children}
+  </section>
+);
 
 export default StyledSection;


### PR DESCRIPTION
## Summary
- simplify `StyledSection` so each section no longer renders its own glow overlay
- rely on `BackgroundGlow` for global gradient effect

## Testing
- `npm run build` *(fails: No native build was found for platform=linux arch=x64 runtime=node)*

------
https://chatgpt.com/codex/tasks/task_e_6882adaa6684832f883739d0f6ac34d1