### PR TITLE
Implement global background glow

### DIFF
--- a/src/components/layout/BackgroundGlow.tsx
+++ b/src/components/layout/BackgroundGlow.tsx
@@ -14,6 +14,12 @@ const BackgroundGlow: React.FC = () => {
 
   return (
     <>
+      {/* 🔵 Static grid + radial light */}
+      <div className="pointer-events-none fixed inset-0 z-0 opacity-40">
+        <div className="absolute inset-0 bg-[url('/grid.svg')] bg-center [mask-image:linear-gradient(180deg,white,rgba(255,255,255,0))]" />
+        <div className="absolute inset-x-0 h-[600px] bg-[radial-gradient(circle_500px_at_50%_200px,#3e3e70,transparent)]" />
+      </div>
+
       {/* 🔵 Mouse-following glow */}
       <div
         className="pointer-events-none fixed inset-0 z-0 transition duration-300"
@@ -21,12 +27,6 @@ const BackgroundGlow: React.FC = () => {
           background: `radial-gradient(800px circle at ${mousePosition.x}px ${mousePosition.y}px, rgba(29, 78, 216, 0.15), transparent 80%)`,
         }}
       />
-
-      {/* 🔵 Static grid + radial light */}
-      <div className="fixed inset-0 z-[-1] opacity-40">
-        <div className="absolute inset-0 bg-[url('/grid.svg')] bg-center [mask-image:linear-gradient(180deg,white,rgba(255,255,255,0))]" />
-        <div className="absolute inset-x-0 h-[600px] bg-[radial-gradient(circle_500px_at_50%_200px,#3e3e70,transparent)]" />
-      </div>
     </>
   );
 };

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -3,7 +3,7 @@ import Container from '../shared/Container';
 import Logo from '../shared/Logo';
 
 const Footer = () => (
-  <footer className="bg-gray-900 py-8 text-sm text-gray-500 border-t border-gray-800">
+  <footer className="bg-transparent py-8 text-sm text-gray-500 border-t border-gray-800">
     <Container className="text-center">
       <Logo />
       <p className="mt-4">&copy; {new Date().getFullYear()} GrowLab. All rights reserved.</p>

--- a/src/components/sections/StyledSection.tsx
+++ b/src/components/sections/StyledSection.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useEffect, useState } from 'react';
+import React, { ReactNode } from 'react';
 
 interface StyledSectionProps {
   children: ReactNode;
@@ -6,38 +6,10 @@ interface StyledSectionProps {
   id?: string;
 }
 
-const StyledSection: React.FC<StyledSectionProps> = ({ children, className = '', id }) => {
-  const [mousePosition, setMousePosition] = useState({ x: 0, y: 0 });
-
-  useEffect(() => {
-    const handleMouseMove = (event: MouseEvent) => {
-      setMousePosition({ x: event.clientX, y: event.clientY });
-    };
-
-    window.addEventListener('mousemove', handleMouseMove);
-    return () => window.removeEventListener('mousemove', handleMouseMove);
-  }, []);
-
-  return (
-    <section id={id} className={`relative w-full overflow-hidden bg-gray-900 text-white ${className}`}>
-      {/* 🔵 Dynamic glow following cursor */}
-      <div
-        className="pointer-events-none absolute inset-0 z-10 transition duration-300"
-        style={{
-          background: `radial-gradient(600px circle at ${mousePosition.x}px ${mousePosition.y}px, rgba(29, 78, 216, 0.15), transparent 80%)`,
-        }}
-      />
-
-      {/* 🔵 Static grid and radial lighting */}
-      <div className="absolute inset-0 z-0 opacity-40">
-        <div className="absolute inset-0 bg-[url('/grid.svg')] bg-center [mask-image:linear-gradient(180deg,white,rgba(255,255,255,0))]" />
-        <div className="absolute inset-x-0 h-[600px] bg-[radial-gradient(circle_500px_at_50%_200px,#3e3e70,transparent)]" />
-      </div>
-
-      {/* 🔵 Foreground content */}
-      <div className="relative z-20">{children}</div>
-    </section>
-  );
-};
+const StyledSection: React.FC<StyledSectionProps> = ({ children, className = '', id }) => (
+  <section id={id} className={`relative w-full bg-transparent ${className}`}>
+    <div className="relative z-10">{children}</div>
+  </section>
+);
 
 export default StyledSection;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -26,7 +26,7 @@ const IndexPage = () => (
       />
     </Helmet>
     <Header />
-    <main className="relative bg-gray-900 text-white">
+    <main className="relative text-white">
       <BackgroundGlow /> {/* ✅ This is your global glow background */}
       <Hero />
       <StyledSection id="features">


### PR DESCRIPTION
## Summary
- make footer transparent so the background glow shows
- drop per-section glow and use a transparent wrapper
- move the static grid below the mouse-following glow
- mount the glow on the page and remove background color from the main element

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882b27f04dc832f8d41bcac8c15dd66