### PR TITLE
Add dedicated product pages

### DIFF
--- a/src/pages/products/ai-tools.tsx
+++ b/src/pages/products/ai-tools.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import Header from '../../components/layout/Header';
+import Footer from '../../components/layout/Footer';
+import Container from '../../components/shared/Container';
+import Button from '../../components/ui/Button';
+
+const AiToolsPage = () => (
+  <>
+    <Header />
+    <section className="bg-gradient-to-b from-[#0A2640] to-[#071B30] py-24 text-white">
+      <Container className="text-center">
+        <h1 className="text-4xl font-bold mb-4">AI Tools</h1>
+        <p className="text-lg text-gray-300 mb-8">Streamline everyday tasks with simple AI-powered helpers.</p>
+        <Button>Get Started</Button>
+        {/* Add custom sections here */}
+      </Container>
+    </section>
+    <Footer />
+  </>
+);
+
+export default AiToolsPage;

--- a/src/pages/products/analytics-reporting.tsx
+++ b/src/pages/products/analytics-reporting.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import Header from '../../components/layout/Header';
+import Footer from '../../components/layout/Footer';
+import Container from '../../components/shared/Container';
+import Button from '../../components/ui/Button';
+
+const AnalyticsReportingPage = () => (
+  <>
+    <Header />
+    <section className="bg-gradient-to-b from-[#0A2640] to-[#071B30] py-24 text-white">
+      <Container className="text-center">
+        <h1 className="text-4xl font-bold mb-4">Analytics &amp; Reporting</h1>
+        <p className="text-lg text-gray-300 mb-8">Track what’s working with simple dashboards and weekly insights.</p>
+        <Button>Get Started</Button>
+        {/* Add custom sections here */}
+      </Container>
+    </section>
+    <Footer />
+  </>
+);
+
+export default AnalyticsReportingPage;

--- a/src/pages/products/automation.tsx
+++ b/src/pages/products/automation.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import Header from '../../components/layout/Header';
+import Footer from '../../components/layout/Footer';
+import Container from '../../components/shared/Container';
+import Button from '../../components/ui/Button';
+
+const AutomationPage = () => (
+  <>
+    <Header />
+    <section className="bg-gradient-to-b from-[#0A2640] to-[#071B30] py-24 text-white">
+      <Container className="text-center">
+        <h1 className="text-4xl font-bold mb-4">Automation</h1>
+        <p className="text-lg text-gray-300 mb-8">Speed up workflows using ready-made Power Automate templates.</p>
+        <Button>Get Started</Button>
+        {/* Add custom sections here */}
+      </Container>
+    </section>
+    <Footer />
+  </>
+);
+
+export default AutomationPage;

--- a/src/pages/products/content-packages.tsx
+++ b/src/pages/products/content-packages.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import Header from '../../components/layout/Header';
+import Footer from '../../components/layout/Footer';
+import Container from '../../components/shared/Container';
+import Button from '../../components/ui/Button';
+
+const ContentPackagesPage = () => (
+  <>
+    <Header />
+    <section className="bg-gradient-to-b from-[#0A2640] to-[#071B30] py-24 text-white">
+      <Container className="text-center">
+        <h1 className="text-4xl font-bold mb-4">Content Packages</h1>
+        <p className="text-lg text-gray-300 mb-8">Fill your site with blog posts, lead magnets, and visuals—all done for you.</p>
+        <Button>Get Started</Button>
+        {/* Add custom sections here */}
+      </Container>
+    </section>
+    <Footer />
+  </>
+);
+
+export default ContentPackagesPage;

--- a/src/pages/products/custom-integrations.tsx
+++ b/src/pages/products/custom-integrations.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import Header from '../../components/layout/Header';
+import Footer from '../../components/layout/Footer';
+import Container from '../../components/shared/Container';
+import Button from '../../components/ui/Button';
+
+const CustomIntegrationsPage = () => (
+  <>
+    <Header />
+    <section className="bg-gradient-to-b from-[#0A2640] to-[#071B30] py-24 text-white">
+      <Container className="text-center">
+        <h1 className="text-4xl font-bold mb-4">Custom Integrations</h1>
+        <p className="text-lg text-gray-300 mb-8">Connect tools like CRMs, email, and databases with tailored solutions.</p>
+        <Button>Get Started</Button>
+        {/* Add custom sections here */}
+      </Container>
+    </section>
+    <Footer />
+  </>
+);
+
+export default CustomIntegrationsPage;

--- a/src/pages/products/email-marketing.tsx
+++ b/src/pages/products/email-marketing.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import Header from '../../components/layout/Header';
+import Footer from '../../components/layout/Footer';
+import Container from '../../components/shared/Container';
+import Button from '../../components/ui/Button';
+
+const EmailMarketingPage = () => (
+  <>
+    <Header />
+    <section className="bg-gradient-to-b from-[#0A2640] to-[#071B30] py-24 text-white">
+      <Container className="text-center">
+        <h1 className="text-4xl font-bold mb-4">Email Marketing</h1>
+        <p className="text-lg text-gray-300 mb-8">Build your list and send newsletters or drip campaigns automatically.</p>
+        <Button>Get Started</Button>
+        {/* Add custom sections here */}
+      </Container>
+    </section>
+    <Footer />
+  </>
+);
+
+export default EmailMarketingPage;

--- a/src/pages/products/graphic-design.tsx
+++ b/src/pages/products/graphic-design.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import Header from '../../components/layout/Header';
+import Footer from '../../components/layout/Footer';
+import Container from '../../components/shared/Container';
+import Button from '../../components/ui/Button';
+
+const GraphicDesignPage = () => (
+  <>
+    <Header />
+    <section className="bg-gradient-to-b from-[#0A2640] to-[#071B30] py-24 text-white">
+      <Container className="text-center">
+        <h1 className="text-4xl font-bold mb-4">Graphic Design</h1>
+        <p className="text-lg text-gray-300 mb-8">Get custom logos and cohesive branding designed for your business.</p>
+        <Button>Get Started</Button>
+        {/* Add custom sections here */}
+      </Container>
+    </section>
+    <Footer />
+  </>
+);
+
+export default GraphicDesignPage;

--- a/src/pages/products/maintenance-support.tsx
+++ b/src/pages/products/maintenance-support.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import Header from '../../components/layout/Header';
+import Footer from '../../components/layout/Footer';
+import Container from '../../components/shared/Container';
+import Button from '../../components/ui/Button';
+
+const MaintenanceSupportPage = () => (
+  <>
+    <Header />
+    <section className="bg-gradient-to-b from-[#0A2640] to-[#071B30] py-24 text-white">
+      <Container className="text-center">
+        <h1 className="text-4xl font-bold mb-4">Maintenance &amp; Support</h1>
+        <p className="text-lg text-gray-300 mb-8">Keep your digital assets running smoothly with proactive updates.</p>
+        <Button>Get Started</Button>
+        {/* Add custom sections here */}
+      </Container>
+    </section>
+    <Footer />
+  </>
+);
+
+export default MaintenanceSupportPage;

--- a/src/pages/products/seo-monetization.tsx
+++ b/src/pages/products/seo-monetization.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import Header from '../../components/layout/Header';
+import Footer from '../../components/layout/Footer';
+import Container from '../../components/shared/Container';
+import Button from '../../components/ui/Button';
+
+const SeoMonetizationPage = () => (
+  <>
+    <Header />
+    <section className="bg-gradient-to-b from-[#0A2640] to-[#071B30] py-24 text-white">
+      <Container className="text-center">
+        <h1 className="text-4xl font-bold mb-4">SEO &amp; Monetization</h1>
+        <p className="text-lg text-gray-300 mb-8">Grow traffic and generate passive income with optimized content.</p>
+        <Button>Get Started</Button>
+        {/* Add custom sections here */}
+      </Container>
+    </section>
+    <Footer />
+  </>
+);
+
+export default SeoMonetizationPage;

--- a/src/pages/products/social-media-management.tsx
+++ b/src/pages/products/social-media-management.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import Header from '../../components/layout/Header';
+import Footer from '../../components/layout/Footer';
+import Container from '../../components/shared/Container';
+import Button from '../../components/ui/Button';
+
+const SocialMediaManagementPage = () => (
+  <>
+    <Header />
+    <section className="bg-gradient-to-b from-[#0A2640] to-[#071B30] py-24 text-white">
+      <Container className="text-center">
+        <h1 className="text-4xl font-bold mb-4">Social Media Management</h1>
+        <p className="text-lg text-gray-300 mb-8">Boost engagement and grow your presence with scheduled content.</p>
+        <Button>Get Started</Button>
+        {/* Add custom sections here */}
+      </Container>
+    </section>
+    <Footer />
+  </>
+);
+
+export default SocialMediaManagementPage;

--- a/src/pages/products/templates-downloads.tsx
+++ b/src/pages/products/templates-downloads.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import Header from '../../components/layout/Header';
+import Footer from '../../components/layout/Footer';
+import Container from '../../components/shared/Container';
+import Button from '../../components/ui/Button';
+
+const TemplatesDownloadsPage = () => (
+  <>
+    <Header />
+    <section className="bg-gradient-to-b from-[#0A2640] to-[#071B30] py-24 text-white">
+      <Container className="text-center">
+        <h1 className="text-4xl font-bold mb-4">Templates &amp; Downloads</h1>
+        <p className="text-lg text-gray-300 mb-8">Access plug-and-play assets like checklists, flows, and branded docs.</p>
+        <Button>Get Started</Button>
+        {/* Add custom sections here */}
+      </Container>
+    </section>
+    <Footer />
+  </>
+);
+
+export default TemplatesDownloadsPage;

--- a/src/pages/products/waas-plans.tsx
+++ b/src/pages/products/waas-plans.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import Header from '../../components/layout/Header';
+import Footer from '../../components/layout/Footer';
+import Container from '../../components/shared/Container';
+import Button from '../../components/ui/Button';
+
+const WaaSPlansPage = () => (
+  <>
+    <Header />
+    <section className="bg-gradient-to-b from-[#0A2640] to-[#071B30] py-24 text-white">
+      <Container className="text-center">
+        <h1 className="text-4xl font-bold mb-4">WaaS Plans</h1>
+        <p className="text-lg text-gray-300 mb-8">Launch a stunning, high-performance website without lifting a finger.</p>
+        <Button>Get Started</Button>
+        {/* Add custom sections here */}
+      </Container>
+    </section>
+    <Footer />
+  </>
+);
+
+export default WaaSPlansPage;


### PR DESCRIPTION
## Summary
- add per-feature product pages in `src/pages/products`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888e1227a50832fbf690eb2db0ce043