### PR TITLE
Apply glow background to blog sections

### DIFF
--- a/src/pages/blog/index.tsx
+++ b/src/pages/blog/index.tsx
@@ -3,11 +3,13 @@ import { Link, graphql } from 'gatsby';
 import Header from '../../components/layout/Header';
 import Footer from '../../components/layout/Footer';
 import Container from '../../components/shared/Container';
+import BackgroundGlow from '../../components/layout/BackgroundGlow';
 
 const BlogIndex = ({ data }: any) => (
   <>
     <Header />
-    <main className="py-20 text-white bg-gradient-to-b from-[#0A2640] to-[#071B30]">
+    <main className="relative py-20 text-white">
+      <BackgroundGlow />
       <Container>
         <h1 className="text-4xl font-bold text-center mb-12">Insights</h1>
 

--- a/src/templates/blog-post.tsx
+++ b/src/templates/blog-post.tsx
@@ -6,6 +6,7 @@ import Header from '../components/layout/Header';
 import Footer from '../components/layout/Footer';
 import Container from '../components/shared/Container';
 import Button from '../components/ui/Button';
+import BackgroundGlow from '../components/layout/BackgroundGlow';
 
 const BlogPostTemplate = ({ data }: any) => {
   const post = data.markdownRemark;
@@ -27,7 +28,8 @@ const BlogPostTemplate = ({ data }: any) => {
         <meta name="description" content={post.excerpt} />
       </Helmet>
       <Header />
-      <main className="bg-gradient-to-b from-[#0A2640] to-[#071B30] py-24 text-white min-h-screen">
+      <main className="relative py-24 text-white min-h-screen">
+        <BackgroundGlow />
         <Container className="max-w-3xl mx-auto">
           <article className="prose prose-invert prose-lg max-w-none">
             <header className="mb-10">


### PR DESCRIPTION
## Summary
- use the global `BackgroundGlow` on the blog index page
- add the glow background on individual blog posts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6889013b15e4832f8686d8f519fa6148